### PR TITLE
Fix the device-info column output from the backend, per 'man backend'.

### DIFF
--- a/setupcloudprint.py
+++ b/setupcloudprint.py
@@ -170,7 +170,7 @@ if __name__ == '__main__':  # pragma: no cover
                     if prefix == "":
                         print "Not using prefix"
 
-                printername = prefix + ccpprinter['name'].encode('ascii', 'replace')
+                printername = prefix + ccpprinter.getDisplayName().encode('ascii', 'replace')
                 found = False
                 for cupsprinter in cupsprinters:
                     if cupsprinters[cupsprinter]['device-uri'] == ccpprinter.getURI():
@@ -207,7 +207,7 @@ if __name__ == '__main__':  # pragma: no cover
             if found:
                 continue
 
-            printername = prefix + ccpprinter['name']
+            printername = prefix + ccpprinter.getDisplayName()
 
             # check if printer name already exists
             foundbyname = False


### PR DESCRIPTION
This fixed a problem in the native OS X printer UI, where all printers are named "Google Cloud Print". 'man backend' shows that the device-info column should have all of the device-name column, plus some. This patch just simply copies the device-name column to the device-info column, but there might be some other field in the GCP search response that could be added (I checked, nothing jumps out at me).
